### PR TITLE
Fix for ruby 3.1

### DIFF
--- a/lib/tqdm/decorator.rb
+++ b/lib/tqdm/decorator.rb
@@ -106,7 +106,7 @@ module Tqdm
     end
 
     def enhanced
-      @enhanced ||= enumerable.clone
+      @enhanced ||= enumerable.dup
     end
 
     def total!


### PR DESCRIPTION
*bug*

The code below raises a `FrozenError`:

```
(0..10).tqdm.map{ sleep 0.1 }
```
This is because the `Range` is frozen. And it is frozen because `#clone` keeps the frozen state.

*solution*

Changing from `#clone` to `#dup`