### PR TITLE
Adds Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['1.9', '2.0', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['1.9', '2.0', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v3
@@ -30,7 +31,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+      uses: ruby/setup-ruby@319066216501fbd5e2d568f14b7d68c19fb67a5d # v1.133.1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
To support this I made the following changes:

1. Upgraded setup-ruby action to 1.133.1 to pick up Ruby 3.2 and bundler fixes.
2. Restored Ruby 2.3, 2.4, and 2.5 which had been removed because setup-ruby was installing an incompatible bundler (now fixed)
3. Added `fail-fast: false` so that all jobs run, even if one or more of them are failing.